### PR TITLE
Configure CircleCI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,70 @@
+version: 2.1
+
+workflows:
+  build-approve-deploy:
+    jobs:
+      - deps
+      - jest-tests:
+          requires:
+            - deps
+      - cypress-tests:
+          requires:
+            - deps
+      - standardjs-lint:
+          requires:
+            - deps
+
+jobs:
+  deps:
+    docker:
+      - image: cypress/base:12
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            npm ci
+      - save_cache:
+          key: git-cache-{{ .Revision }}
+          paths: .
+      - save_cache:
+          key: node-cache-{{ checksum "package-lock.json" }}
+          paths:
+            - node_modules
+            - /root/.cache/Cypress
+
+  jest-tests:
+    docker:
+      - image: cypress/base:12
+    steps:
+      - restore_cache:
+          key: git-cache-{{ .Revision }}
+      - restore_cache:
+          key: node-cache-{{ checksum "package-lock.json" }}
+      - run:
+          name: Run unit tests
+          command: npm run test:unit
+
+  cypress-tests:
+    docker:
+      - image: cypress/base:12
+    steps:
+      - restore_cache:
+          key: git-cache-{{ .Revision }}
+      - restore_cache:
+          key: node-cache-{{ checksum "package-lock.json" }}
+      - run:
+          name: Run feature tests
+          command: npm run test:feature:ci
+
+  standardjs-lint:
+    docker:
+      - image: cypress/base:12
+    steps:
+      - restore_cache:
+          key: git-cache-{{ .Revision }}
+      - restore_cache:
+          key: node-cache-{{ checksum "package-lock.json" }}
+      - run:
+          name: Run StandardJS linter
+          command: npm run lint

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -11,7 +11,7 @@ const dotenvPlugin = require('cypress-dotenv')
 module.exports = (on, config) => {
   config = dotenvPlugin(
     config, {
-      path: '.env.local'
+      path: '.env.test'
     },
     true
   )

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -13,9 +13,7 @@ const responseStub = (result) => Promise.resolve({
 Cypress.Commands.add('stubRequest', (fixture, operationName) => {
   cy.fixture(fixture).then((data) => {
     cy.on('window:before:load', (win) => {
-      const fetchGraphQl = () => {
-        return responseStub(data[operationName])
-      }
+      const fetchGraphQl = () => responseStub(data[operationName])
 
       cy.stub(win, 'fetch')
         .withArgs(Cypress.env('NEXT_PUBLIC_GRAPHQL_URI'))


### PR DESCRIPTION
Quick Info
---

| Issue |
| -- | 
| #10 |

What does this change?
----
- [x] Fix environment variable pointers on Cypress;
- [x] Configure CircleCI workflows by adding these jobs:
 + `deps`: The dependencies installation job
 + `jest-tests`: Run unit tests
 + `cypress-tests`: Run feature tests in CI mode (start-server-and-test)
 + `standardjs-lint`: Simply run the `StandardJS Linter`
