### PR TITLE
Configure Heroku deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "solidus_nextjs_frontend",
   "version": "0.1.0",
+  "engines": {
+    "node": "12.18.3"
+  },
   "standard": {
     "env": [
       "jest"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev": "next",
     "test": "NODE_ENV=test next -p 3333",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p ${PORT-3000}",
     "lint": "standard",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@apollo/client": "^3.0.2",
     "graphql": "^15.3.0",
-    "next": "latest",
+    "next": "^9.5.3",
     "normalize.css": "^8.0.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",


### PR DESCRIPTION
Quick Info
---

| Issue |
| -- | 
| N/A |

What does this change?
----
- [x] Set up a Heroku project for previews and staging environments.
- [x] Fix configuration problems:
 - Use the dynamic port served  by `Heroku` with the [$PORT](https://help.heroku.com/P1AVPANS/why-is-my-node-js-app-crashing-with-an-r10-error) environment variable;
 - Set a `Node.js` version in the `package.json` to allow Heroku to install the correct one;
 - Fix minor problems related to dependencies not correctly processed by Heroku during installation.

How can I test this
----
Visit the preview deployed in this PR: https://solidus-nextjs-pr-16.herokuapp.com/