### PR TITLE
Add global footer

### DIFF
--- a/components/button/__snapshots__/test.js.snap
+++ b/components/button/__snapshots__/test.js.snap
@@ -6,7 +6,7 @@ Object {
   "baseElement": <body>
     <div>
       <button
-        class="button__StyledButton-sc-19djgr1-0 iQxsUP"
+        class="button__StyledButton-sc-19djgr1-0 esiBmb"
         type="primary"
       >
         Click Me!
@@ -15,7 +15,7 @@ Object {
   </body>,
   "container": <div>
     <button
-      class="button__StyledButton-sc-19djgr1-0 iQxsUP"
+      class="button__StyledButton-sc-19djgr1-0 esiBmb"
       type="primary"
     >
       Click Me!
@@ -81,7 +81,7 @@ Object {
   "baseElement": <body>
     <div>
       <button
-        class="button__StyledButton-sc-19djgr1-0 jwfdKo"
+        class="button__StyledButton-sc-19djgr1-0 spRMM"
         type="secondary"
       >
         Click Me!
@@ -90,7 +90,7 @@ Object {
   </body>,
   "container": <div>
     <button
-      class="button__StyledButton-sc-19djgr1-0 jwfdKo"
+      class="button__StyledButton-sc-19djgr1-0 spRMM"
       type="secondary"
     >
       Click Me!

--- a/components/button/index.js
+++ b/components/button/index.js
@@ -2,20 +2,20 @@ import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 
 const StyledButton = styled.button`
-  color: ${(props) => props.theme.color.copy.bright};
+  color: ${(props) => props.theme.colors.copy.bright};
   border-radius: 2px;
   padding: 0 30px;
   height: 40px;
   outline: none;
   cursor: pointer;
   ${(props) => props.type === 'primary' && css`
-    background-color: ${props.theme.color.accent};
+    background-color: ${props.theme.colors.accent};
     border: 0;
   `}
   ${(props) => props.type === 'secondary' && css`
-    background-color: ${props.theme.color.copy.bright};
-    color: ${props.theme.color.accent};
-    border: 1px solid ${props.theme.color.accent};
+    background-color: ${props.theme.colors.copy.bright};
+    color: ${props.theme.colors.accent};
+    border: 1px solid ${props.theme.colors.accent};
   `}
 `
 

--- a/containers/footer/__snapshots__/test.js.snap
+++ b/containers/footer/__snapshots__/test.js.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Footer renders correctly 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <footer
+        class="footer__StyledFooter-sc-13z5uuo-0 hJKNFb"
+      >
+        <div
+          class="footer__Container-sc-13z5uuo-1 bDBTlX"
+        >
+          <p>
+            Powered by 
+            <a
+              href="http://solidus.io/"
+            >
+              Solidus
+            </a>
+          </p>
+        </div>
+      </footer>
+    </div>
+  </body>,
+  "container": <div>
+    <footer
+      class="footer__StyledFooter-sc-13z5uuo-0 hJKNFb"
+    >
+      <div
+        class="footer__Container-sc-13z5uuo-1 bDBTlX"
+      >
+        <p>
+          Powered by 
+          <a
+            href="http://solidus.io/"
+          >
+            Solidus
+          </a>
+        </p>
+      </div>
+    </footer>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/containers/footer/index.js
+++ b/containers/footer/index.js
@@ -1,0 +1,29 @@
+import styled from 'styled-components'
+
+import Link from 'next/link'
+
+const StyledFooter = styled.footer`
+  background-color: ${(props) => props.theme.colors.background.light};
+  color: ${(props) => props.theme.colors.copy.light};
+  padding: 8rem 2rem;
+  font-size: 1.3rem;
+  margin: 4rem 0 0;
+`
+
+const Container = styled.div`
+  max-width: ${(props) => props.theme.sizes.container};
+  margin: 0 auto;
+  text-align: center;
+`
+
+const Footer = () => (
+  <StyledFooter>
+    <Container>
+      <p>
+        Powered by <Link href='http://solidus.io/'>Solidus</Link>
+      </p>
+    </Container>
+  </StyledFooter>
+)
+
+export default Footer

--- a/containers/footer/index.stories.js
+++ b/containers/footer/index.stories.js
@@ -1,0 +1,11 @@
+import Footer from '.'
+
+export default {
+  title: 'Footer',
+  component: Footer
+}
+
+const Template = (args) => <Footer {...args} />
+
+export const DefaultFooter = Template.bind({})
+DefaultFooter.args = {}

--- a/containers/footer/test.js
+++ b/containers/footer/test.js
@@ -1,0 +1,13 @@
+import Footer from '.'
+
+let footer
+
+describe('Footer', () => {
+  beforeEach(() => {
+    footer = render(<Footer />)
+  })
+
+  it('renders correctly', () => {
+    expect(footer).toMatchSnapshot()
+  })
+})

--- a/containers/index.js
+++ b/containers/index.js
@@ -1,7 +1,9 @@
 import CategoriesNavigation from '../containers/categories-navigation'
 import ProductsList from './products-list'
+import Footer from './footer'
 
 export {
   CategoriesNavigation,
-  ProductsList
+  ProductsList,
+  Footer
 }

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -1,8 +1,22 @@
+const palette = {
+  white: '#FFFFFF',
+  blue: '#3C76f0',
+  concrete: '#F2F2F2',
+  boulder: '#777777'
+}
+
 export const theme = {
-  color: {
-    accent: '#3C76f0',
+  sizes: {
+    container: '114rem'
+  },
+  colors: {
+    accent: palette.blue,
     copy: {
-      bright: '#ffffff'
+      bright: palette.white,
+      light: palette.boulder
+    },
+    background: {
+      light: palette.concrete
     }
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,6 +5,7 @@ import 'normalize.css'
 
 import { useApollo } from '../lib/apolloClient'
 import { theme } from '../lib/theme'
+import { Footer } from '../containers'
 
 const GlobalStyle = createGlobalStyle`
   a {
@@ -20,6 +21,7 @@ export default function App ({ Component, pageProps }) {
       <ThemeProvider theme={theme}>
         <GlobalStyle />
         <Component {...pageProps} />
+        <Footer />
       </ThemeProvider>
     </ApolloProvider>
   )

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,16 @@
 import { ApolloProvider } from '@apollo/client'
-import { ThemeProvider } from 'styled-components'
+import { ThemeProvider, createGlobalStyle } from 'styled-components'
 
 import 'normalize.css'
 
 import { useApollo } from '../lib/apolloClient'
 import { theme } from '../lib/theme'
+
+const GlobalStyle = createGlobalStyle`
+  a {
+    color: ${(props) => props.theme.colors.copy.light};
+  }
+`
 
 export default function App ({ Component, pageProps }) {
   const apolloClient = useApollo(pageProps.initialApolloState)
@@ -12,6 +18,7 @@ export default function App ({ Component, pageProps }) {
   return (
     <ApolloProvider client={apolloClient}>
       <ThemeProvider theme={theme}>
+        <GlobalStyle />
         <Component {...pageProps} />
       </ThemeProvider>
     </ApolloProvider>


### PR DESCRIPTION
Fixes: #18 

- Add the footer colors and dimensions
- Add the `Footer` container
- Add the new components to the storybook

![image](https://user-images.githubusercontent.com/9986708/94935143-ecf12c00-04cc-11eb-9b10-8dfb9b6efe49.png)

**Important: I used the `rem` unit to define dimensions and now they are different from the solidus starter frontend because we didn't set the body `font-size` yet**